### PR TITLE
Handle ProcessLookupError/ESRCH gracefully

### DIFF
--- a/prelockd
+++ b/prelockd
@@ -232,7 +232,7 @@ def get_current_set():
             if lifetime >= min_save_lifetime:
                 uniq_map_d[uniq_id] = uniq_map_set
 
-        except FileNotFoundError as e:
+        except (FileNotFoundError, ProcessLookupError) as e:
             errprint(e)
             continue
 


### PR DESCRIPTION
Fixing the following error that I got while compiling some things, i.e. creating many short-lived processes.
```
Traceback (most recent call last):
  File "/nix/store/p98m77qy0ggdmwiyr801hq4s9zvi76zb-prelockd-0.9/bin/prelockd", line 938, in <module>
    current_set = get_current_set()
  File "/nix/store/p98m77qy0ggdmwiyr801hq4s9zvi76zb-prelockd-0.9/bin/prelockd", line 221, in get_current_set
    lines_list = f.read().decode('utf-8', 'ignore').split('\n')
ProcessLookupError: [Errno 3] No such process
```

There might be other places that also could benefit from a similar change, but I am not familiar enough with the code to judge.