### PR TITLE
Fix deprecation of `sre_constants`

### DIFF
--- a/prelockd
+++ b/prelockd
@@ -4,9 +4,8 @@ from ctypes import CDLL
 from json import dump, load
 from mmap import ACCESS_READ, mmap
 from os import getpid, listdir, path, sysconf, sysconf_names, times
-from re import search
+from re import error as re_error, search
 from signal import SIGHUP, SIGINT, SIGQUIT, SIGTERM, signal
-from sre_constants import error as invalid_re
 from sys import argv, exit, stderr, stdout
 from time import monotonic, process_time, sleep
 
@@ -46,7 +45,7 @@ def valid_re(reg_exp):
     """
     try:
         search(reg_exp, '')
-    except invalid_re:
+    except re_error:
         errprint('Invalid config: invalid regexp: {}'.format(reg_exp))
         exit(1)
 


### PR DESCRIPTION
Fix #13

I tested it with `[` as an invalid regex and it failed with the message error `Invalid config: invalid regexp: [` as expected, but there’s no deprecation warning anymore.